### PR TITLE
Upgrade nix to 0.9 (map nix::Error to io::Error)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "os_pipe"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Jack O'Connor"]
 description = "a cross-platform library for opening OS pipes"
 repository = "https://github.com/oconnor663/os_pipe.rs"
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/os_pipe"
 license = "MIT"
 
 [target.'cfg(not(windows))'.dependencies]
-nix = "^0.8.0"
+nix = "^0.9.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "^0.2.8"


### PR DESCRIPTION
Hi, I've made a small change to allow updating the version of nix. I'm fairly new to rust and to github, so sorry if I've got anything wrong.