### PR TITLE
Update winapi from 0.2 to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,4 @@ license = "MIT"
 nix = "^0.9.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "^0.2.8"
-kernel32-sys = "^0.2.2"
+winapi = { version = "^0.3.4", features = ["handleapi", "namedpipeapi", "processenv", "winbase"] }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,5 +1,4 @@
 extern crate winapi;
-extern crate kernel32;
 
 use std::fs::File;
 use std::io;
@@ -7,20 +6,24 @@ use std::os::windows::prelude::*;
 use std::process::Stdio;
 use std::ptr;
 
+use self::winapi::shared::minwindef::DWORD;
+use self::winapi::shared::ntdef::{HANDLE, PHANDLE};
+use self::winapi::um::{handleapi, namedpipeapi, processenv, winbase};
+
 use PipeReader;
 use PipeWriter;
 use IntoStdio;
 
 pub fn pipe() -> io::Result<(PipeReader, PipeWriter)> {
-    let mut read_pipe: winapi::HANDLE = ptr::null_mut();
-    let mut write_pipe: winapi::HANDLE = ptr::null_mut();
+    let mut read_pipe: HANDLE = ptr::null_mut();
+    let mut write_pipe: HANDLE = ptr::null_mut();
 
     let ret = unsafe {
         // TODO: These pipes do not support IOCP. We might want to emulate anonymous pipes with
         // CreateNamedPipe, as Rust's stdlib does.
-        kernel32::CreatePipe(
-            &mut read_pipe as winapi::PHANDLE,
-            &mut write_pipe as winapi::PHANDLE,
+        namedpipeapi::CreatePipe(
+            &mut read_pipe as PHANDLE,
+            &mut write_pipe as PHANDLE,
             ptr::null_mut(),
             0,
         )
@@ -31,29 +34,29 @@ pub fn pipe() -> io::Result<(PipeReader, PipeWriter)> {
     } else {
         unsafe {
             Ok((
-                PipeReader::from_raw_handle(read_pipe),
-                PipeWriter::from_raw_handle(write_pipe),
+                PipeReader::from_raw_handle(read_pipe as _),
+                PipeWriter::from_raw_handle(write_pipe as _),
             ))
         }
     }
 }
 
 pub fn parent_stdin() -> io::Result<Stdio> {
-    dup_std_handle(winapi::STD_INPUT_HANDLE)
+    dup_std_handle(winbase::STD_INPUT_HANDLE)
 }
 
 pub fn parent_stdout() -> io::Result<Stdio> {
-    dup_std_handle(winapi::STD_OUTPUT_HANDLE)
+    dup_std_handle(winbase::STD_OUTPUT_HANDLE)
 }
 
 pub fn parent_stderr() -> io::Result<Stdio> {
-    dup_std_handle(winapi::STD_ERROR_HANDLE)
+    dup_std_handle(winbase::STD_ERROR_HANDLE)
 }
 
 // adapted from src/libstd/sys/windows/stdio.rs
-fn dup_std_handle(which: winapi::DWORD) -> io::Result<Stdio> {
-    let handle = unsafe { kernel32::GetStdHandle(which) };
-    if handle == winapi::INVALID_HANDLE_VALUE {
+fn dup_std_handle(which: DWORD) -> io::Result<Stdio> {
+    let handle = unsafe { processenv::GetStdHandle(which) };
+    if handle == handleapi::INVALID_HANDLE_VALUE {
         return Err(io::Error::last_os_error());
     }
     if handle.is_null() {
@@ -65,7 +68,7 @@ fn dup_std_handle(which: winapi::DWORD) -> io::Result<Stdio> {
     // This handle is *not* a dup. It's just a copy of the global stdin/stdout/stderr handle, and
     // we need to dup it ourselves. The simplest way to do that is File::try_clone(), but we need
     // to make sure that the file is never dropped.
-    let temp_file = unsafe { File::from_raw_handle(handle) };
+    let temp_file = unsafe { File::from_raw_handle(handle as _) };
     let dup_result = temp_file.try_clone(); // No short-circuit here!
     temp_file.into_raw_handle(); // Prevent closing handle on drop().
     dup_result.map(File::into_stdio)


### PR DESCRIPTION
The new version has been out for a while now. Updating reduces version conflicts with downstream packages and also reduces compile time.