### PR TITLE
Update nix to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/os_pipe"
 license = "MIT"
 
 [target.'cfg(not(windows))'.dependencies]
-nix = "0.12.0"
+nix = "0.13.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.5", features = ["handleapi", "namedpipeapi", "processenv", "winbase"] }


### PR DESCRIPTION
After checking the usage of the nix API in os_pipe, this should be a semver compatible change.