### PR TITLE
add illumos and Solaris support

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -11,15 +11,7 @@ use std::os::unix::prelude::*;
 // we can do is call pipe() followed by fcntl(), and hope that no other threads
 // fork() in between. The following code is copied from the nix crate, where it
 // works but is deprecated.
-#[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "emscripten",
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
 fn pipe2_cloexec() -> io::Result<(c_int, c_int)> {
     let mut fds: [c_int; 2] = [0; 2];
     let res = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };


### PR DESCRIPTION
With this change, I'm able to get the tests to pass on an [illumos](https://illumos.org) system.

```
$ uname -o
illumos

$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.01s
     Running target/debug/deps/os_pipe-4e54df13c69a5c73

running 9 tests
test tests::test_debug ... ok
test tests::test_parent_handles_dont_close ... ok
test tests::test_pipe_no_data ... ok
test tests::test_pipe_some_data_with_refs ... ok
test tests::test_pipe_some_data ... ok
test tests::test_try_clone ... ok
test tests::test_pipe_a_megabyte_of_data_from_another_thread ... ok
test tests::test_pipes_are_not_inheritable ... ok
test tests::test_parent_handles ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/cat-23bddc2238a1b3d1

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/cat_both-6182c20994663f1a

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/swap-4a4cb57d9bce86f2

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests os_pipe

running 1 test
test src/lib.rs -  (line 46) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Our heritage is (from long ago) in OpenSolaris.  I've checked the Oracle Solaris manual page and they appear to support the requisite flags for `pipe2()`.  I am not able to test this on Solaris myself at the moment.