### PR TITLE
add haiku support

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -11,7 +11,7 @@ use std::os::unix::prelude::*;
 // we can do is call pipe() followed by fcntl(), and hope that no other threads
 // fork() in between. The following code is copied from the nix crate, where it
 // works but is deprecated.
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "haiku")))]
 fn pipe2_cloexec() -> io::Result<(c_int, c_int)> {
     let mut fds: [c_int; 2] = [0; 2];
     let res = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
@@ -21,7 +21,7 @@ fn pipe2_cloexec() -> io::Result<(c_int, c_int)> {
     Ok((fds[0], fds[1]))
 }
 
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(any(target_os = "ios", target_os = "macos", target_os = "haiku"))]
 fn pipe2_cloexec() -> io::Result<(c_int, c_int)> {
     let mut fds: [c_int; 2] = [0; 2];
     let res = unsafe { libc::pipe(fds.as_mut_ptr()) };


### PR DESCRIPTION
hello 👋 

the following pr adds build support for haiku. a sample test run on a haiku host is shown below:

```

> uname -a
Haiku shredder 1 hrev55891 Feb 19 2022 08:17:46 x86_64 x86_64 Haiku

> cargo test
   Compiling libc v0.2.119
   Compiling os_pipe v1.0.0 (/boot/home/src/git/rust-libs/os_pipe.rs)
    Finished test [unoptimized + debuginfo] target(s) in 7.12s
     Running unittests (target/debug/deps/os_pipe-d86de2364d87edcc)

running 9 tests
test tests::test_parent_handles_dont_close ... ok
test tests::test_debug ... ok
test tests::test_pipe_no_data ... ok
test tests::test_pipe_some_data_with_refs ... ok
test tests::test_pipe_some_data ... ok
test tests::test_try_clone ... ok
test tests::test_pipe_a_megabyte_of_data_from_another_thread ... ok
test tests::test_pipes_are_not_inheritable ... ok
test tests::test_parent_handles ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.74s

     Running unittests (target/debug/deps/cat-b07bf0fda55996e4)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/cat_both-6b98e0ae94d8eb96)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/swap-87b80de883d8eaf8)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests os_pipe

running 2 tests
test src/lib.rs - (line 47) ... ok
test src/lib.rs - (line 77) ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.64s
```