### PR TITLE
Implement I/O safety traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,5 @@ jobs:
         profile: minimal
         override: true
     - run: cargo test
+    # notgull: check io_safety feature with CI
+    - run: cargo check --features io_safety

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ libc = "0.2.62"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.5", features = ["handleapi", "namedpipeapi", "processthreadsapi", "winnt"] }
+
+[features]
+# Uses I/O safety features introduced in Rust 1.63
+io_safety = []

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -90,3 +90,45 @@ impl FromRawFd for PipeWriter {
         PipeWriter(File::from_raw_fd(fd))
     }
 }
+
+#[cfg(feature = "io_safety")]
+impl From<PipeReader> for OwnedFd {
+    fn from(pr: PipeReader) -> Self {
+         pr.0.into()
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl AsFd for PipeReader {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_fd()
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl From<OwnedFd> for PipeReader {
+    fn from(fd: OwnedFd) -> Self {
+        PipeReader(fd.into())
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl From<PipeWriter> for OwnedFd {
+    fn from(pw: PipeWriter) -> Self {
+        pw.0.into()
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl AsFd for PipeWriter {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_fd()
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl From<OwnedFd> for PipeWriter {
+    fn from(fd: OwnedFd) -> Self {
+        PipeWriter(fd.into())
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -111,3 +111,45 @@ impl FromRawHandle for PipeWriter {
         PipeWriter(File::from_raw_handle(handle))
     }
 }
+
+#[cfg(feature = "io_safety")]
+impl From<PipeReader> for OwnedHandle {
+    fn from(reader: PipeReader) -> Self {
+        reader.0.into() 
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl AsHandle for PipeReader {
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        self.0.as_handle()
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl From<OwnedHandle> for PipeReader {
+    fn from(handle: OwnedHandle) -> Self {
+        PipeReader(handle.into())
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl From<PipeWriter> for OwnedHandle {
+    fn from(writer: PipeWriter) -> Self {
+        writer.0.into()
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl AsHandle for PipeWriter {
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        self.0.as_handle()
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl From<OwnedHandle> for PipeWriter {
+    fn from(handle: OwnedHandle) -> Self {
+        PipeWriter(handle.into())
+    }
+}


### PR DESCRIPTION
This pull request adds a new feature: `io_safety`. When this feature is enabled, `AsFd/Handle`, `From<OwnedFd/Handle>` and `Into<OwnedFd/Handle>` are implemented for `PipeReader` and `PipeWriter`. Note that enabling this feature bumps the MSRV to 1.63.

See also: sunfishcode/io-lifetimes#38