### PR TITLE
Switch from winapi to windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 libc = "0.2.62"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.5", features = ["handleapi", "namedpipeapi", "processthreadsapi", "winnt"] }
+windows-sys = { version = "0.42.0", features = ["Win32_Foundation", "Win32_System_Pipes", "Win32_Security", "Win32_System_Threading"] }
 
 [features]
 # Uses I/O safety features introduced in Rust 1.63


### PR DESCRIPTION
The Rust ecosystem is migrating from winapi to windows-sys, for example https://github.com/tokio-rs/tokio/pull/5204