### PR TITLE
Update to windows-sys 0.45.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 libc = "0.2.62"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.42.0", features = ["Win32_Foundation", "Win32_System_Pipes", "Win32_Security", "Win32_System_Threading"] }
+windows-sys = { version = "0.45.0", features = ["Win32_Foundation", "Win32_System_Pipes", "Win32_Security", "Win32_System_Threading"] }
 
 [features]
 # Uses I/O safety features introduced in Rust 1.63


### PR DESCRIPTION
[io-lfetimes] and [other crates] are starting to update to windows-sys 0.45, so here's a PR to update os_pipe to windows-sys 0.45 too!

[io-lfetimes]: https://github.com/sunfishcode/io-lifetimes/issues/60
[other crates]: https://crates.io/crates/windows-sys/reverse_dependencies