### PR TITLE
Update to windows-sys 0.48.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 libc = "0.2.62"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.45.0", features = ["Win32_Foundation", "Win32_System_Pipes", "Win32_Security", "Win32_System_Threading"] }
+windows-sys = { version = "0.48.0", features = ["Win32_Foundation", "Win32_System_Pipes", "Win32_Security", "Win32_System_Threading"] }
 
 [features]
 # Uses I/O safety features introduced in Rust 1.63


### PR DESCRIPTION
I need this because I'm getting duplicate dependency errors in a project which depends on `os-pipe` and `is_terminal`.