### PR TITLE
update windows-sys to 0.61 or earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,5 @@ jobs:
       with:
         toolchain: ${{ matrix.rust_channel }}
     - run: cargo test
+    - run: cargo +nightly update -Zminimal-versions
+    - run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.63"
 libc = "0.2.62"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.60.2", features = ["Win32_Foundation", "Win32_System_Pipes", "Win32_Security"] }
+windows-sys = { version = ">=0.28, <=0.61", features = ["Win32_Foundation", "Win32_System_Pipes", "Win32_Security"] }
 
 [features]
 # Integration with IO safety types like OwnedFd is now always enabled, and this


### PR DESCRIPTION
windows-sys is a frequent source of duplicate dependencies.  Widening the range of allowed versions gives downstream crates a fighting chance of being able to select one unique version of it.